### PR TITLE
Add back nginx pod. Containerize certbot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ QUEUE.json
 sql_app.db
 .env
 certs/
+certbot/
+ShazamIO
+.terraform/

--- a/app/app.py
+++ b/app/app.py
@@ -14,26 +14,6 @@ def register_app(app,process_manager):
     queue_thread = threading.Thread(target=process_manager.process_queue, daemon=True)
     queue_thread.start()
 
-
-    origins = [
-        "http://192.168.1.100:5173", 
-        "http://localhost:5173",     
-        "http://localhost", 
-        "https://always12.duckdns.org/", 
-        "http://always12.duckdns.org/",
-        "http://raspberry:5173/"    
-    ]
-
-    # Add CORS middleware
-    app.add_middleware(
-        CORSMiddleware,
-        # allow_origins=origins,           # Origins that are allowed to make requests
-        allow_credentials=True,         # Allow cookies and authorization headers
-        allow_methods=["*"],            # Allowed HTTP methods (GET, POST, etc.)
-        allow_headers=["*"],            # Allowed HTTP headers
-        allow_origins=["*"]
-    )
-
     from app.api.rtmp_endpoints import rtmp_blueprint
     from app.api.http_endpoints import http_blueprint
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,20 +23,19 @@ services:
   #     # Add as many environment variables as needed
   #   restart: unless-stopped
 
-  # nginx-rtmp:
-  #   container_name: nginx
-  #   network_mode: host
-  #   build:
-  #     context: ./nginx-config
-  #     dockerfile: Dockerfile
-  #   volumes: 
-  #     - ./nginx-config/nginx.conf:/etc/nginx/nginx.conf
-  #     - ./nginx-config/rtmp.conf:/etc/nginx/rtmp.conf
-  #     # - ./nginx-config/https-config.conf:/etc/nginx/conf.d/https-config.conf
-  #     # - ./certs/always12:/etc/letsencrypt/live/always12.duckdns.org/
-  #     # - ./certs/always12wiki:/etc/letsencrypt/live/always12wiki.duckdns.org/
-  #     # - ./certs/motherstream:/etc/letsencrypt/live/motherstream.duckdns.org/
-  #     - /var/www:/var/www
+  nginx-rtmp:
+    container_name: nginx
+    network_mode: host
+    build:
+      context: ./nginx-config
+      dockerfile: Dockerfile
+    volumes: 
+      - ./nginx-config/nginx.conf:/etc/nginx/nginx.conf
+      - ./nginx-config/rtmp.conf:/etc/nginx/rtmp.conf
+      - ./nginx-config/https-config.conf:/etc/nginx/conf.d/https-config.conf
+      - ./certs/:/etc/letsencrypt/
+      - ./certbot/www/:/var/www/certbot/:ro
+      # - /var/www:/var/www
   oryx:
     container_name: oryx
     network_mode: host
@@ -51,3 +50,8 @@ services:
     volumes:
       - /home/danielamar/Desktop/onyx:/data
     restart: unless-stopped
+  # certbot:
+  #   image: certbot/certbot:latest
+  #   volumes:
+  #     - ./certbot/www/:/var/www/certbot/:rw
+  #     - ./certs/:/etc/letsencrypt/:rw

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,7 +8,7 @@ import { StrictMode } from "react"
 import { OpenAPI } from "./client"
 import theme from "./theme"
 
-OpenAPI.BASE = "http://localhost:8483"
+OpenAPI.BASE = "https://always12.duckdns.org"
 OpenAPI.TOKEN = async () => {
   return localStorage.getItem("access_token") || ""
 }

--- a/main.py
+++ b/main.py
@@ -46,10 +46,19 @@ async def lifespan(app: FastAPI):
     logger.info("SERVER SHUTDOWN")
     process_manager.obs_socket_manager.disconnect()
     
-middleware = [
-Middleware(
+origins = [
+    "http://192.168.1.100:5173", 
+    "http://localhost:5173",     
+    "http://localhost", 
+    "https://always12.duckdns.org/", 
+    "http://always12.duckdns.org/",
+    "http://raspberry:5173/",
+    "http://motherstream.xyz",    
+    "https://motherstream.xyz"    
+]
+middleware = [ Middleware(
     CORSMiddleware,
-    allow_origins=['*'],
+    allow_origins=origins,
     allow_credentials=True,
     allow_methods=['*'],
     allow_headers=['*']

--- a/nginx-config/Dockerfile
+++ b/nginx-config/Dockerfile
@@ -1,0 +1,58 @@
+FROM buildpack-deps:bullseye
+
+
+# Versions of Nginx and nginx-rtmp-module to use
+ENV NGINX_VERSION nginx-1.23.2
+ENV NGINX_RTMP_MODULE_VERSION 1.2.2
+
+# Install dependencies
+RUN apt-get update && \
+    apt-get install -y ca-certificates openssl libssl-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+# Download and decompress Nginx
+RUN mkdir -p /tmp/build/nginx && \
+    cd /tmp/build/nginx && \
+    wget -O ${NGINX_VERSION}.tar.gz https://nginx.org/download/${NGINX_VERSION}.tar.gz && \
+    tar -zxf ${NGINX_VERSION}.tar.gz
+
+# Download and decompress RTMP module
+RUN mkdir -p /tmp/build/nginx-rtmp-module && \
+    cd /tmp/build/nginx-rtmp-module && \
+    wget -O nginx-rtmp-module-${NGINX_RTMP_MODULE_VERSION}.tar.gz https://github.com/arut/nginx-rtmp-module/archive/v${NGINX_RTMP_MODULE_VERSION}.tar.gz && \
+    tar -zxf nginx-rtmp-module-${NGINX_RTMP_MODULE_VERSION}.tar.gz && \
+    cd nginx-rtmp-module-${NGINX_RTMP_MODULE_VERSION}
+
+# Build and install Nginx
+# The default puts everything under /usr/local/nginx, so it's needed to change
+# it explicitly. Not just for order but to have it in the PATH
+RUN cd /tmp/build/nginx/${NGINX_VERSION} && \
+    ./configure \
+        --sbin-path=/usr/local/sbin/nginx \
+        --conf-path=/etc/nginx/nginx.conf \
+        --error-log-path=/var/log/nginx/error.log \
+        --pid-path=/var/run/nginx/nginx.pid \
+        --lock-path=/var/lock/nginx/nginx.lock \
+        --http-log-path=/var/log/nginx/access.log \
+        --http-client-body-temp-path=/tmp/nginx-client-body \
+        --with-http_stub_status_module \
+        --with-http_slice_module \
+        --with-http_ssl_module \
+        --with-http_v2_module \ 
+        --with-threads \
+        --with-ipv6 \
+        --add-module=/tmp/build/nginx-rtmp-module/nginx-rtmp-module-${NGINX_RTMP_MODULE_VERSION} --with-debug && \
+    make -j $(getconf _NPROCESSORS_ONLN) && \
+    make install && \
+    mkdir /var/lock/nginx && \
+    rm -rf /tmp/build
+
+# Forward logs to Docker
+RUN ln -sf /dev/stdout /var/log/nginx/access.log && \
+    ln -sf /dev/stderr /var/log/nginx/error.log
+
+# Set up config file
+COPY nginx.conf /etc/nginx/nginx.conf
+
+EXPOSE 1935
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx-config/https-config.conf
+++ b/nginx-config/https-config.conf
@@ -1,0 +1,222 @@
+map $http_upgrade $connection_upgrade {
+  default upgrade;
+  '' close;
+}
+
+
+log_format stripsecrets '$remote_addr $host - $remote_user [$time_local] '
+                    '"$secretfilter" $status $body_bytes_sent '
+                    '$request_length $request_time $upstream_response_time '
+                    '"$http_referer" "$http_user_agent"';
+
+map $request $secretfilter {
+    ~*^(?<prefix1>.*[\?&]api_key=)([^&]*)(?<suffix1>.*)$  "${prefix1}***$suffix1";
+    default                                               $request;
+}
+
+server {
+                                                                                                                               
+    listen 80;                                                                                                                         
+    listen [::]:80;                                                                                                                    
+    server_name motherstream.xyz;                                                                                             
+    server_tokens off; 
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://motherstream.xyz$request_uri;
+    }  
+}
+
+server {
+                                                                                                                               
+    listen 80;                                                                                                                         
+    listen [::]:80;                                                                                                                    
+    server_name always12.duckdns.org;                                                                                             
+    server_tokens off;       
+    
+                                                                                                              
+	
+    access_log /var/log/nginx/access.log stripsecrets;
+                                                                                                                        
+    # HLS http CONFIG
+    location /hls/ {
+        alias /var/www/hls/;
+        types {
+            application/vnd.apple.mpegurl m3u8;
+            # video/mp2t ts;∏
+        }
+
+        add_header Cache-Control no-cache;
+        add_header 'Access-Control-Allow-Origin' '*' always;
+    }
+
+   #Upgrade regular requests to 301
+    location / {                                                                                                                       
+        return 301 https://always12.duckdns.org$request_uri;                                                                      
+    }
+
+
+    location /local/ {
+#	proxy_hide_header X-Frame-Options;
+        add_header X-Frame-Options SAMEORIGIN always;
+	alias /usr/share/nginx/html/local/;
+        try_files $uri $uri/ =404;
+    }
+                                                                                                                                   
+                                                                                                                                      
+    location /.well-known/acme-challenge/ {                                                                                            
+        root /var/www/certbot;                                                                                                         
+    }
+
+   
+}
+
+server {rewrite ^(/.well-known/acme-challenge/.*) $1 break; # managed by Certbot
+
+                                                                                                                               
+    listen 443 ssl http2;                                                                                                                                                                                                                                                                                                      
+    server_name motherstream.xyz;
+    ssl_certificate /etc/letsencrypt/live/motherstream.xyz/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/motherstream.xyz/privkey.pem; # managed by Certbot                                            
+    ssl_protocols       TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+    ssl_ciphers         HIGH:!aNULL:!MD5;                                                                                                                                    
+    add_header Strict-Transport-Security "max-age=31536000" always;
+    add_header X-Frame-Options "SAMEORIGIN";
+
+
+    access_log /var/log/nginx/access.log stripsecrets;
+
+
+    ### MOTHERSTREAM CONFIG
+
+    location / {
+
+        proxy_pass http://127.0.0.1:5173/;
+        proxy_http_version 1.1;
+
+        proxy_pass_request_headers on;
+
+        proxy_set_header Host $host;
+
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $http_host;
+
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $http_connection;
+
+        proxy_cache_bypass $http_upgrade;
+        # Optional: Increase timeouts
+        proxy_connect_timeout 60s;
+        proxy_read_timeout 60s;
+        proxy_send_timeout 60s;
+
+        # try_files $uri $uri/ /motherstream/index.html;
+        # Disable buffering when the nginx proxy gets very resource heavy upon streaming
+        proxy_buffering off;
+    }
+    location /backend/ {
+
+        proxy_pass http://127.0.0.1:8483/;
+        proxy_http_version 1.1;
+
+        proxy_pass_request_headers on;
+
+        proxy_set_header Host $host;
+
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $http_host;
+
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $http_connection;
+
+        proxy_cache_bypass $http_upgrade;
+        # Optional: Increase timeouts
+        proxy_connect_timeout 60s;
+        proxy_read_timeout 60s;
+        proxy_send_timeout 60s;
+
+        # try_files $uri $uri/ /motherstream/index.html;
+        # Disable buffering when the nginx proxy gets very resource heavy upon streaming
+        proxy_buffering off;
+    }
+
+    if ($scheme != "https") {
+        return 301 https://$host$request_uri;
+    }
+
+}
+                                                                                                                                      
+server {                                                                                                                               
+    listen 443 ssl http2;                                                                                                                                                                                                               
+    server_name always12.duckdns.org;
+    ssl_certificate /etc/letsencrypt/live/always12.duckdns.org/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/always12.duckdns.org/privkey.pem; # managed by Certbot                                            
+    ssl_protocols       TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+    ssl_ciphers         HIGH:!aNULL:!MD5;                                                                                                                                    
+    add_header Strict-Transport-Security "max-age=31536000" always;
+    add_header X-Frame-Options "SAMEORIGIN";
+
+    access_log /var/log/nginx/access.log stripsecrets;
+
+    location / {
+
+        proxy_pass http://127.0.0.1:8483/;
+        proxy_http_version 1.1;
+
+        proxy_pass_request_headers on;
+
+        proxy_set_header Host $host;
+
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $http_host;
+
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $http_connection;
+
+        proxy_cache_bypass $http_upgrade;
+        # Optional: Increase timeouts
+        proxy_connect_timeout 60s;
+        proxy_read_timeout 60s;
+        proxy_send_timeout 60s;
+
+        # try_files $uri $uri/ /motherstream/index.html;
+        # Disable buffering when the nginx proxy gets very resource heavy upon streaming
+        proxy_buffering off;
+    }
+    ### STREAM STAT CONFIG
+
+    location /stat {
+        proxy_pass http://127.0.0.1:8989/stat;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Optional: Increase proxy timeout if needed
+        proxy_connect_timeout 60s;
+        proxy_read_timeout 60s;
+        proxy_send_timeout 60s;
+    }
+
+    # HLS CONFIG 
+
+    location /hls/ {
+        alias /var/www/hls/;
+        types {
+            application/vnd.apple.mpegurl m3u8;
+        }
+
+        add_header Cache-Control no-cache;
+        add_header 'Access-Control-Allow-Origin' '*' always;
+    }
+  
+}

--- a/nginx-config/nginx.conf
+++ b/nginx-config/nginx.conf
@@ -1,0 +1,123 @@
+user www-data;
+worker_processes 1;
+pid /run/nginx.pid;
+error_log /var/log/nginx/error.log debug;
+include /etc/nginx/modules-enabled/*.conf;
+# load_module /usr/lib/nginx/modules/ngx_rtmp_module.so;
+include /etc/nginx/rtmp.conf;
+# include /etc/nginx/conf.d/https.conf
+events {
+	worker_connections 768;
+	# multi_accept on;
+}
+
+http {
+	
+	server {
+		listen 8989;
+
+		root /var/www/html;
+
+		server_name localhost;
+		location = /basic_status {
+    		# stub_status;
+	
+		}
+
+		location / {
+				try_files $uri $uri/ =404;
+				index index.html index.htm index.nginx-debian.html;
+		}
+
+		# location /control {
+        #     rtmp_control all;
+        # }
+
+		location /stat {
+			rtmp_stat all;
+			rtmp_stat_stylesheet stat.xsl;
+			# Allow access from any visitor
+			allow all;
+			# Live updates for the stat page
+			add_header Refresh "3; $request_uri";
+		}
+
+		location /control {
+        	rtmp_control all;
+     	}
+
+		location /stat.xsl {
+			root /var/www/;
+		}
+	}
+
+	##
+	# Basic Settings
+	##
+
+	sendfile on;
+	tcp_nopush on;
+	types_hash_max_size 2048;
+	# server_tokens off;
+
+	# server_names_hash_bucket_size 64;
+	# server_name_in_redirect off;
+
+	include /etc/nginx/mime.types;
+	default_type application/octet-stream;
+
+	##
+	# SSL Settings
+	##
+
+	ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3; # Dropping SSLv3, ref: POODLE
+	ssl_prefer_server_ciphers on;
+
+	##
+	# Logging Settings
+	##
+
+	access_log /var/log/nginx/access.log;
+
+	##
+	# Gzip Settings
+	##
+
+	gzip on;
+
+	# gzip_vary on;
+	# gzip_proxied any;
+	# gzip_comp_level 6;
+	# gzip_buffers 16 8k;
+	# gzip_http_version 1.1;
+	# gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+	##
+	# Virtual Host Configs
+	##
+
+	include /etc/nginx/conf.d/*.conf;
+	include /etc/nginx/sites-enabled/*;
+}
+
+
+#mail {
+#	# See sample authentication script at:
+#	# http://wiki.nginx.org/ImapAuthenticateWithApachePhpScript
+#
+#	# auth_http localhost/auth.php;
+#	# pop3_capabilities "TOP" "USER";
+#	# imap_capabilities "IMAP4rev1" "UIDPLUS";
+#
+#	server {
+#		listen     localhost:110;
+#		protocol   pop3;
+#		proxy      on;
+#	}
+#
+#	server {
+#		listen     localhost:143;
+#		protocol   imap;
+#		proxy      on;
+#	}
+#}

--- a/nginx-config/rtmp.conf
+++ b/nginx-config/rtmp.conf
@@ -1,0 +1,18 @@
+rtmp {
+        server {
+                listen 1936;
+                chunk_size 4096;
+
+        	# Increase buffer size
+		out_queue 4096;
+		out_cork 8;
+
+		application live {
+			live on;
+
+                        record all manual;
+                        record_path /var/www/streams/stream-recordings;
+                        record_suffix -%m-%d-%H-%M.flv;
+		}
+        }
+}

--- a/scripts/get_certs.sh
+++ b/scripts/get_certs.sh
@@ -1,0 +1,1 @@
+sudo docker-compose run --rm certbot certonly --webroot --webroot-path /var/www/certbot/ -d always12.duckdns.org

--- a/srs/srs.vhost.conf
+++ b/srs/srs.vhost.conf
@@ -1,0 +1,27 @@
+# !!! Important: This file is produced and maintained by the Oryx, please never modify it.
+
+hls {
+    enabled on;
+    hls_fragment 10;
+    hls_window 60;
+    hls_aof_ratio 2.1;
+    hls_path ./objs/nginx/html;
+    hls_m3u8_file [app]/[stream].m3u8;
+    hls_ts_file [app]/[stream]-[seq]-[timestamp].ts;
+    hls_wait_keyframe on;
+    hls_dispose 15;
+}
+
+forward {
+    enabled on;
+    backend http://127.0.0.1:8483/;
+}
+
+http_hooks {
+    # whether the http hooks enable.
+    # default off.
+    enabled         on;
+    on_publish      http://127.0.0.1:8483/;
+    on_unpublish      http://127.0.0.1:8483/;
+
+}


### PR DESCRIPTION
 - Get certbot to generate ssl certs for configurations based on nginx/config/. 
 - Essentually containerize the certificate creation and usage process. 
 - Change frontend to use nginx route instead of tailscale network. 
 - Add back CORS security.
